### PR TITLE
Deployment docs: Easier secret gen

### DIFF
--- a/content/en/docs/Deployment/_index.md
+++ b/content/en/docs/Deployment/_index.md
@@ -51,7 +51,7 @@ works.
 
 {{% alert title="Tip" color="info" %}}
 You can also run
-`python -c "import os; f=open('.ctfd_secret_key', 'a+'); f.write(os.urandom(64)); f.close()"`
+`cat /dev/urandom | head -c64 > .ctfd_secret_key`
 within the CTFd repo to generate a .ctfd_secret_key file.
 {{% /alert %}}
 


### PR DESCRIPTION
I changed the commands used for generating a secret key to native Linux commands instead of Python 2, it's shorter and more ubiquitous, as Python 2 isn't very common to be pre-installed on systems anymore.